### PR TITLE
Quote debian-sys-maint mysql user

### DIFF
--- a/manifests/debian.pp
+++ b/manifests/debian.pp
@@ -23,7 +23,7 @@ class galera::debian {
   if ($::fqdn == $galera::galera_master) {
     # Debian sysmaint pw will be set on the master,
     # and needs to be consistent across the cluster.
-    mysql_user { 'debian-sys-maint@localhost':
+    mysql_user { '"debian-sys-maint"@localhost':
       ensure        => 'present',
       password_hash => mysql_password($galera::deb_sysmaint_password),
       provider      => 'mysql',
@@ -35,7 +35,7 @@ class galera::debian {
       owner     => 'mysql',
       group     => 'mysql',
       content   => template('galera/debian.cnf.erb'),
-      require   => Mysql_user['debian-sys-maint@localhost']
+      require   => Mysql_user['"debian-sys-maint"@localhost']
     }
   } else {
     file { '/etc/mysql/debian.cnf':

--- a/spec/classes/galera_debian_spec.rb
+++ b/spec/classes/galera_debian_spec.rb
@@ -31,14 +31,14 @@ describe 'galera::debian' do
     end
     let(:node) { 'control1' }
 
-    it { should contain_mysql_user('debian-sys-maint@localhost').with(
+    it { should contain_mysql_user('"debian-sys-maint"@localhost').with(
       :ensure   => 'present',
       :provider => 'mysql',
       :require  => "File[/root/.my.cnf]"
     ) }
 
     it { should contain_file('/etc/mysql/debian.cnf').with(
-      :require => 'Mysql_user[debian-sys-maint@localhost]'
+      :require => 'Mysql_user["debian-sys-maint"@localhost]'
     ) }
 
     it { should_not contain_file('/etc/mysql/debian.cnf').with(
@@ -55,14 +55,14 @@ describe 'galera::debian' do
     end
     let(:node) { 'slave' }
 
-    it { should_not contain_mysql_user('debian-sys-maint@localhost').with(
+    it { should_not contain_mysql_user('"debian-sys-maint"@localhost').with(
       :ensure   => 'present',
       :provider => 'mysql',
       :require  => "File[/root/.my.cnf]"
     ) }
 
     it { should_not contain_file('/etc/mysql/debian.cnf').with(
-      :require => 'Mysql_user[debian-sys-maint@localhost]'
+      :require => 'Mysql_user["debian-sys-maint"@localhost]'
     ) }
   end
 end


### PR DESCRIPTION
The latest tagged copy of the mysql module (3.1.0) requires that names
with special characters be properly quoted per mysql rules. This makes
it so that puppet-galera will work with puppetlabs-mysql 3.1.0.
