### PR TITLE
fix conflict with class mysql::backup::xtrabackup

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -125,6 +125,9 @@
 # [*manage_package_nmap*]
 #   (optional) Whether the package nmap should be installed
 #
+# [*manage_additional_packages*]
+#   (optional) Whether additional packages should be installed
+#
 class galera(
   $galera_servers                   = [$::ipaddress_eth1],
   $galera_master                    = $::fqdn,
@@ -154,6 +157,7 @@ class galera(
   $status_password                  = undef,
   $service_enabled                  = undef,
   $manage_package_nmap              = true,
+  $manage_additional_packages       = true,
 )
 {
   if $configure_repo {
@@ -230,7 +234,7 @@ class galera(
     before  => Class['mysql::server::installdb']
   }
 
-  if $galera::params::additional_packages {
+  if $manage_additional_packages and $galera::params::additional_packages {
     ensure_resource(package, $galera::params::additional_packages,
     {
       ensure  => $package_ensure,


### PR DESCRIPTION
Currently if you want to use `mysql::backup::xtrabackup` to backup your Galera cluster you'll hit a duplicate declaration error:

> Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Evaluation Error: Error while evaluating a Resource Statement, Duplicate declaration: Package[percona-xtrabackup] is already declared; cannot redeclare at /etc/puppet/environments/development/modules/mysql/manifests/backup/xtrabackup.pp:25

Both classes `galera` and `mysql::backup::xtrabackup` require the package to be installed. My patch makes it possible to control the installation of these additional packages by setting `$manage_additional_packages` to `false` to resolve this conflict.
