### PR TITLE
allow custom values for parameter $mysql_service_name

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -197,6 +197,7 @@ class galera(
   $package_ensure                   = 'installed',
   $status_password                  = undef,
   $service_enabled                  = undef,
+  $mysql_service_name               = undef,
   $manage_package_nmap              = true,
   $status_allow                     = '%',
   $status_host                      = 'localhost',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,28 +17,28 @@ class galera::params {
 
   if ($::osfamily == 'RedHat') {
     if $galera::vendor_type == 'percona' {
-      $mysql_service_name = 'mysql'
+      $mysql_service_name_internal = 'mysql'
       $mysql_package_name_internal = 'Percona-XtraDB-Cluster-server-55'
       $galera_package_name_internal = 'Percona-XtraDB-Cluster-galera-2'
       $client_package_name_internal = 'Percona-XtraDB-Cluster-client-55'
       $libgalera_location = '/usr/lib64/libgalera_smm.so'
     }
     elsif $galera::vendor_type == 'mariadb' {
-      $mysql_service_name = 'mysql'
+      $mysql_service_name_internal = 'mysql'
       $mysql_package_name_internal = 'MariaDB-Galera-server'
       $galera_package_name_internal = 'galera'
       $client_package_name_internal = 'MariaDB-client'
       $libgalera_location = '/usr/lib64/galera/libgalera_smm.so'
     }
     elsif $galera::vendor_type == 'codership' {
-      $mysql_service_name = 'mysql'
+      $mysql_service_name_internal = 'mysqld'
       $mysql_package_name_internal = 'mysql-wsrep-5.5'
       $galera_package_name_internal = 'galera-3'
       $client_package_name_internal = 'mysql-wsrep-client-5.5'
       $libgalera_location = '/usr/lib64/galera-3/libgalera_smm.so'
     }
     elsif $galera::vendor_type == 'osp5' {
-      $mysql_service_name           = 'mariadb'
+      $mysql_service_name_internal  = 'mariadb'
       $mysql_package_name_internal  = 'mariadb-galera-server'
       $galera_package_name_internal = 'galera'
       $client_package_name_internal = 'mariadb'
@@ -52,7 +52,7 @@ class galera::params {
 
   }
   elsif ($::osfamily == 'Debian'){
-    $mysql_service_name = 'mysql'
+    $mysql_service_name_internal = 'mysql'
     if $galera::vendor_type == 'percona' {
       if $galera::vendor_version == '5.6' {
         $mysql_package_name_internal = 'percona-xtradb-cluster-server-5.6'
@@ -159,5 +159,9 @@ class galera::params {
   $client_package_name = pick(
     $::galera::client_package_name,
     $client_package_name_internal
+  )
+  $mysql_service_name = pick(
+    $::galera::mysql_service_name,
+    $mysql_service_name_internal
   )
 }


### PR DESCRIPTION
This patch makes it possible to set a custom value for `$mysql_service_name`. This may be required in some situations due to the crazy amount of different repo/operatingsystem combinations.

Besides that it fixes the services name on CentOS when using the Codership repository.