### PR TITLE
Add notify trigger after apt source is included

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -95,6 +95,7 @@ class galera::repo(
             include  => {
               'src' => $apt_mariadb_repo_include_src,
             },
+            notify   => Exec['apt_update'],
           }
         } elsif ($repo_vendor == 'codership') {
           apt::source { 'galera_codership_repo':
@@ -108,8 +109,10 @@ class galera::repo(
             include  => {
               'src' => $apt_codership_repo_include_src,
             },
+            notify   => Exec['apt_update'],
           }
         }
+        Exec['apt_update'] -> Package<||>
       }
       if ($repo_vendor == 'osp5') {
         fail('OSP5 is only supported on RHEL platforms.')


### PR DESCRIPTION
On Ubuntu servers an apt update was missing before installing packages
This commits tries to fix that notifying apt_update after apt::source
and before packages