### PR TITLE
add galera_package_parameter, so we can ensure version on galera package

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -123,6 +123,12 @@
 #   (Optional) Ensure state for package.
 #   Defaults to 'installed'
 #
+# [*galera_package_ensure*]
+#   (Optional) Ensure state for Galera package.
+#   In some distibutions Galera package should have different versioning. You
+#   can use this variable to lock galera package.
+#   Defaults to 'installed'
+#
 # [*service_enabled*]
 #   (optional) Whether the mysql service should be enabled
 #   Defaults to undef
@@ -204,6 +210,7 @@ class galera(
   $galera_package_name            = undef,
   $client_package_name            = undef,
   $package_ensure                 = 'installed',
+  $galera_package_ensure          = 'installed',
   $status_password                = undef,
   $service_enabled                = undef,
   $mysql_service_name             = undef,
@@ -309,7 +316,7 @@ class galera(
   package{[
       $galera::params::galera_package_name,
       ] :
-    ensure  => $package_ensure,
+    ensure  => $galera_package_ensure,
     before  => Class['mysql::server::install'],
     require => Class['mysql::server::config']
   }


### PR DESCRIPTION
Hello, 
at least on my platform (Ubuntu and Percona), MySQL and Galera packages have different versioning :

```
[root@machine ~  ]# apt-cache policy percona-xtradb-cluster-common-5.6
percona-xtradb-cluster-common-5.6:
  Installed: 5.6.36-26.20-1.xenial
  Candidate: 5.6.37-26.21-3.xenial
  Version table:
     5.6.37-26.21-3.xenial 500
        500 http://apt/stable xenial/percona amd64 Packages
 *** 5.6.36-26.20-1.xenial 100
        100 /var/lib/dpkg/status
[root@machine ~  ]# apt-cache policy percona-xtradb-cluster-galera-3.x
percona-xtradb-cluster-galera-3.x:
  Installed: 3.20-4.xenial
  Candidate: 3.21-3.xenial
  Version table:
     3.21-3.xenial 500
        500 http://apt/stable xenial/percona amd64 Packages
 *** 3.20-4.xenial 100
        100 /var/lib/dpkg/status
```

It should be useful so one can do version lock even on galera package.
Does this work make sense and can be merged?

Thanks