### PR TITLE
Porting to use the new mysql::deepmerge function

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -169,7 +169,7 @@ class galera(
   }
 
   # Finally merge options from all 3 sources.
-  $options = mysql_deepmerge($_default_options, $_wsrep_cluster_address, $_override_options)
+  $options = mysql::deepmerge($_default_options, $_wsrep_cluster_address, $_override_options)
 
   if ($create_root_user =~ String) {
     $create_root_user_real = $create_root_user


### PR DESCRIPTION
The `mysql_deepmerge` function was flawed and will crash on Puppet version 5.5.7. This changes your code to use the new version of the function, which does not have this flaw.  See https://tickets.puppetlabs.com/browse/MODULES-8193 for more details.