### PR TITLE
Fix mariadb repo handling

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -42,9 +42,9 @@ galera::repo::codership_apt_location: "http://releases.galeracluster.com/mysql-w
 galera::repo::codership_apt_release: "%{os.distro.codename}"
 galera::repo::codership_apt_repos: 'main'
 galera::repo::mariadb_apt_include_src: false
-galera::repo::mariadb_apt_key: '6DC53DD92B7A8C298D5E54F950371E2B8950D2F2'
+galera::repo::mariadb_apt_key: '177F4010FE56CA3336300305F1656F24C74CD1D8'
 galera::repo::mariadb_apt_key_server: 'keyserver.ubuntu.com'
-galera::repo::mariadb_apt_location: "http://mirror.rackspace.com/mariadb/repo/<%= $vendor_version_real %>/ubuntu"
+galera::repo::mariadb_apt_location: "http://mirror.rackspace.com/mariadb/repo/<%= $vendor_version_real %>/%{os_name_lc}"
 galera::repo::mariadb_apt_release: "%{os.distro.codename}"
 galera::repo::mariadb_apt_repos: 'main'
 galera::repo::percona_apt_include_src: false


### PR DESCRIPTION
This PR fixes 2 things:

1. For mariadb_apt_location "ubuntu" is statically used but %{os_name_lc} should be used like it's done for the other apt_locations.

2. The PGP Key for mariadb changed with Ubuntu 16.04 LTS and Debian 9

Fixes #132 