### PR TITLE
fixed scope and handling of deb_sysmaint_password

### DIFF
--- a/manifests/debian.pp
+++ b/manifests/debian.pp
@@ -43,17 +43,13 @@ class galera::debian {
     require     => Class['mysql::server::install'],
   }
 
-  # Assign this locally so that it is in scope for the template below.
-  # Required for Puppet 4
-  $deb_sysmaint_password = $galera::deb_sysmaint_password
-
   if ($::fqdn == $galera::galera_master) {
 
     # Debian sysmaint pw will be set on the master,
     # and needs to be consistent across the cluster.
     mysql_user { 'debian-sys-maint@localhost':
       ensure        => 'present',
-      password_hash => mysql_password($deb_sysmaint_password),
+      password_hash => mysql_password($galera::deb_sysmaint_password),
       provider      => 'mysql',
       require       => File['/root/.my.cnf'],
     }

--- a/templates/debian.cnf.epp
+++ b/templates/debian.cnf.epp
@@ -1,11 +1,11 @@
 [client]
 host     = localhost
 user     = debian-sys-maint
-password = <%= $deb_sysmaint_password %>
+password = <%= $galera::deb_sysmaint_password %>
 socket   = /var/run/mysqld/mysqld.sock
 [mysql_upgrade]
 host     = localhost
 user     = debian-sys-maint
-password = <%= $deb_sysmaint_password %>
+password = <%= $galera::deb_sysmaint_password %>
 socket   = /var/run/mysqld/mysqld.sock
 basedir  = /usr


### PR DESCRIPTION
This PR fixes the scope of `deb_sysmaint_password` and removes the no longer needed "scope handling" in `manifests/debian.pp`

Fixes #136 