### PR TITLE
Fix README typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ It will try to recover from failures by bootstrapping on a node designated as th
 
 ## Requirements
 
-* Puppet 4.10 or higher
+* Puppet 5 or higher
 * puppetlabs-mysql
 
 ## Usage
@@ -42,88 +42,105 @@ It will try to recover from failures by bootstrapping on a node designated as th
 
 Basic usage requires only the FQDN of the master node, a list of IP addresses of other nodes and two passwords:
 
-    class { 'galera':
-        galera_servers  => ['10.0.99.101', '10.0.99.102'],
-        galera_master   => 'node1.example.com',
-        root_password   => 'pa$$w0rd',
-        status_password => 'pa$$w0rd',
-    }
+```puppet
+class { 'galera':
+  galera_servers  => ['10.0.99.101', '10.0.99.102'],
+  galera_master   => 'node1.example.com',
+  root_password   => 'pa$$w0rd',
+  status_password => 'pa$$w0rd',
+}
+```
 
 This will install the default galera vendor and version. However, in a production environment you should definitely specify the vendor and version to avoid accidential updates:
 
-    class { 'galera':
-        vendor_type     => 'percona',
-        vendor_version  => '5.7',
-        ...
+```puppet
+class { 'galera':
+  vendor_type    => 'percona',
+  vendor_version => '5.7',
+  ...
+```
 
 On Debian/Ubuntu systems the user `debian-sys-maint@localhost` is required for updates and will be created automatically, but you should set a proper password:
 
-    class { 'galera':
-        deb_sysmaint_password => 'secretpassword',
-        ...
+```puppet
+class { 'galera':
+  deb_sysmaint_password => 'secretpassword',
+  ...
+```
 
 Furthermore, a number of simple options are available:
 
-    class { 'galera':
-        galera_servers  => ['10.0.99.101', '10.0.99.102'],
-        galera_master   => 'node1.example.com',
-        root_password   => 'pa$$w0rd',
-        status_password => 'pa$$w0rd',
+```puppet
+class { 'galera':
+  galera_servers  => ['10.0.99.101', '10.0.99.102'],
+  galera_master   => 'node1.example.com',
+  root_password   => 'pa$$w0rd',
+  status_password => 'pa$$w0rd',
 
-        # Default is 'percona'
-        vendor_type     => 'codership',
+  # Default is 'percona'
+  vendor_type     => 'codership',
 
-        # This will be used to populate my.cnf values that
-        # control where wsrep binds, advertises, and listens
-        local_ip => $facts['networking']['ip'],
+  # This will be used to populate my.cnf values that
+  # control where wsrep binds, advertises, and listens
+  local_ip => $facts['networking']['ip'],
 
-        # This will be set when the cluster is bootstrapped
-        root_password => 'myrootpassword',
+  # This will be set when the cluster is bootstrapped
+  root_password => 'myrootpassword',
 
-        # Disable this if you don't want firewall rules to be set
-        configure_firewall => true,
+  # Disable this if you don't want firewall rules to be set
+  configure_firewall => true,
 
-        # These options are only used for the firewall - 
-        # to change the my.cnf settings, use the override options
-        # described below
-        $mysql_port = 3306, 
-        $wsrep_state_transfer_port = 4444,
-        $wsrep_inc_state_transfer_port = 4568,
+  # These options are only used for the firewall -
+  # to change the my.cnf settings, use the override options
+  # described below
+  mysql_port => 3306,
+  wsrep_state_transfer_port => 4444,
+  wsrep_inc_state_transfer_port => 4568,
 
-        # This is used for the firewall + for status checks
-        # when deciding whether to bootstrap
-        $wsrep_group_comm_port = 4567,
-    }
+  # This is used for the firewall + for status checks
+  # when deciding whether to bootstrap
+  wsrep_group_comm_port => 4567,
+}
+```
 
 A catch-all parameter can be used to populate my.cnf in the same way as the puppetlabs-mysql module:
 
-    class { 'galera':
-        override_options = {
-            'mysqld' => {
-                'bind_address' => '0.0.0.0',
-            }
-        }
-        ...
+```puppet
+class { 'galera':
+  override_options => {
+    'mysqld' => {
+      'bind_address' => '0.0.0.0',
+    }
+  }
+  ...
+}
+```
 
 ### Custom repository configuration
 
 Disable repo management if you are managing your own repos and mirrors:
 
-    class { 'galera':
-        configure_repo => disable,
-        ...
+```puppet
+class { 'galera':
+  configure_repo => false,
+  ...
+}
+```
 
 Or if you just want to switch to using a local mirror:
 
     # RHEL-based systems
-    class { 'galera::repo':
-        yum_baseurl => "http://repo.example.com/release/${facts['os']['release']['major']}/RPMS/${facts['os']['architecture']}/",
-        ...
-
+```puppet
+class { 'galera::repo':
+  yum_baseurl => "http://repo.example.com/release/${facts['os']['release']['major']}/RPMS/${facts['os']['architecture']}/",
+  ...
+```
     # Debian-based systems
-    class { 'galera::repo':
-        apt_location => "http://repo.example.com/apt/${facts['os']['distro']['codename']}/",
-        ...
+```puppet
+class { 'galera::repo':
+  apt_location => "http://repo.example.com/apt/${facts['os']['distro']['codename']}/",
+  ...
+```
 
 ## Reference
 


### PR DESCRIPTION
  * Puppet 5 is minimum version.
  * Changed `configure_repo => disabled` to `configure_repo => false`.
  * Added syntax highlighting to markdown and fixed syntax errors this
  highlighted.