### PR TITLE
Add `mariabackup` to `wsrep_sst_method` Enum

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -7,5 +7,6 @@ fixtures:
       ref: '2.2.2'
     "firewall": "git://github.com/puppetlabs/puppetlabs-firewall.git"
     "xinetd": "git://github.com/puppetlabs/puppetlabs-xinetd.git"
-  symlinks:
-    "galera": "#{source_dir}"
+    yumrepo_core:
+      repo: "https://github.com/puppetlabs/puppetlabs-yumrepo_core"
+      puppet_version: ">= 6.0.0"

--- a/data/Debian-family.yaml
+++ b/data/Debian-family.yaml
@@ -27,6 +27,18 @@ galera::mariadb::103::mysql_package_name: 'mariadb-server-10.3'
 galera::mariadb::bootstrap_command: '/usr/bin/galera_new_cluster'
 galera::mariadb::libgalera_location: '/usr/lib/galera/libgalera_smm.so'
 galera::mariadb::mysql_service_name: 'mysql'
+galera::sst::mariabackup::mariadb::101::additional_packages:
+  - 'mariadb-backup-10.1'
+  - 'socat'
+galera::sst::mariabackup::mariadb::102::additional_packages:
+  - 'mariadb-backup-10.2'
+  - 'socat'
+galera::sst::mariabackup::mariadb::103::additional_packages:
+  - 'mariadb-backup'
+  - 'socat'
+galera::sst::mariabackup::mariadb::104::additional_packages:
+  - 'mariadb-backup'
+  - 'socat'
 
 galera::percona::55::client_package_name: 'percona-xtradb-cluster-client-5.5'
 galera::percona::55::galera_package_name: 'percona-xtradb-cluster-galera-2.x'

--- a/data/RedHat-family.yaml
+++ b/data/RedHat-family.yaml
@@ -27,6 +27,18 @@ galera::mariadb::103::mysql_package_name: 'MariaDB-server'
 galera::mariadb::bootstrap_command: '/usr/bin/galera_new_cluster'
 galera::mariadb::libgalera_location: '/usr/lib64/galera/libgalera_smm.so'
 galera::mariadb::mysql_service_name: 'mysql'
+galera::sst::mariabackup::mariadb::101::additional_packages:
+  - 'MariaDB-backup'
+  - 'socat'
+galera::sst::mariabackup::mariadb::102::additional_packages:
+  - 'MariaDB-backup'
+  - 'socat'
+galera::sst::mariabackup::mariadb::103::additional_packages:
+  - 'MariaDB-backup'
+  - 'socat'
+galera::sst::mariabackup::mariadb::104::additional_packages:
+  - 'MariaDB-backup'
+  - 'socat'
 
 galera::osp::5::client_package_name: 'mariadb'
 galera::osp::5::galera_package_name: 'galera'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,7 +41,7 @@ class galera(
   Integer $wsrep_group_comm_port,
   Integer $wsrep_inc_state_transfer_port,
   String $wsrep_sst_auth,
-  Enum['mysqldump', 'rsync', 'skip', 'xtrabackup', 'xtrabackup-v2'] $wsrep_sst_method,
+  Enum['mariabackup', 'mysqldump', 'rsync', 'skip', 'xtrabackup', 'xtrabackup-v2'] $wsrep_sst_method,
   Integer $wsrep_state_transfer_port,
   # optional parameters
   # (some of them are actually required, see notes)

--- a/spec/classes/galera_init_spec.rb
+++ b/spec/classes/galera_init_spec.rb
@@ -24,12 +24,10 @@ describe 'galera' do
   end
 
   shared_examples_for 'galera' do
-    it { should contain_class('galera::params') }
 
     context 'with default parameters' do
       it { should contain_class('galera::repo') }
       it { should contain_class('galera::firewall') }
-      it { should contain_class('galera::params') }
 
       it { should contain_class('mysql::server').with(
         :package_name => os_params[:p_mysql_package_name],
@@ -68,6 +66,12 @@ describe 'galera' do
     context 'when using xtrabackup-v2' do
       before { params.merge!( :wsrep_sst_method => 'xtrabackup-v2' ) }
       it { should contain_package('percona-xtrabackup').with(:ensure => 'installed') }
+    end
+
+    context 'when using mariabackup' do
+      before { params.merge!( :vendor_type => 'mariadb', :wsrep_sst_method => 'mariabackup' ) }
+      it { should contain_package(os_params[:m_mariadb_backup_package_name]).with_ensure('installed') }
+      it { should contain_package('socat').with_ensure('installed') }
     end
 
     context 'when managing root .my.cnf' do
@@ -151,7 +155,7 @@ describe 'galera' do
     end
   end
 
-  on_supported_os.each do |os,facts|
+  on_supported_os(:facterversion => '3.6').each do |os,facts|
     context "on #{os}" do
       let (:facts) do
         facts.merge({ })
@@ -175,6 +179,7 @@ describe 'galera' do
             :c_libgalera_location  => '/usr/lib64/galera-3/libgalera_smm.so',
             :c_additional_packages => 'rsync',
             :mysql_service_name    => 'mysql',
+            :m_mariadb_backup_package_name => 'MariaDB-backup',
           }
         elsif facts[:osfamily] == 'Debian'
           { :p_mysql_package_name  => 'percona-xtradb-cluster-server-5.5',
@@ -193,6 +198,7 @@ describe 'galera' do
             :c_libgalera_location  => '/usr/lib/libgalera_smm.so',
             :c_additional_packages => 'rsync',
             :mysql_service_name    => 'mysql',
+            :m_mariadb_backup_package_name => 'mariadb-backup',
           }
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,8 @@ require 'shared_examples'
 require 'rspec-puppet-facts'
 include RspecPuppetFacts
 
+add_custom_fact :root_home, '/root'
+
 RSpec.configure do |c|
   c.alias_it_should_behave_like_to :it_configures, 'configures'
   c.alias_it_should_behave_like_to :it_raises, 'raises'


### PR DESCRIPTION
By default, the correct mariadb-backup package and `socat` packages will
also be installed when using this `sst_method`.

I've been testing this on RedHat 7 with mariadb 10.3.  It *should* also work fine (install the correct extra packages) on Debian systems. Either way, this should be a pretty safe change as the default sst method is still rsync.

I've fixed up the tests just enough to get the new ones I've added to pass.