### PR TITLE
creating rundir and logdir from init.pp not repo.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -118,6 +118,13 @@ class galera(
   if ($facts['os']['family'] == 'Debian') {
     include galera::debian
   }
+  # as well as EL7 with MariaDB
+  # Puppetlabs/mysql forces to use /var/run/mariadb and /var/log/mariadb but they don't exist
+  # so mariadb service won't start. This is amended with galera::mariadb
+  if $vendor_type == 'mariadb' and $facts['os']['family'] == 'RedHat' {
+    include galera::mariadb
+    Class['galera::mariadb'] -> Class['mysql::server::installdb']
+  }
 
   if $status_check {
     include galera::status

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -104,10 +104,6 @@ class galera::repo(
           gpgkey         => "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-${facts['os']['release']['major']}"
         }
       }
-
-      if $vendor_type == 'mariadb' {
-        include galera::mariadb
-      }
     }
     default: {
       fail("Operating system ${facts['os']['family']} is not currently supported")


### PR DESCRIPTION
When configure_repo => false the class galera::mariadb is not applied which leads to impossible to start mariadb service