### PR TITLE
galera::status must be conditionally included

### DIFF
--- a/manifests/validate.pp
+++ b/manifests/validate.pp
@@ -17,6 +17,7 @@ class galera::validate(
   Integer $delay,
   Integer $retries,
   Optional[String] $inv_catch,
+  Optional[String] $host = $galera::status_host,
 ) {
 
   if $galera::root_password =~ String {

--- a/manifests/validate.pp
+++ b/manifests/validate.pp
@@ -17,7 +17,9 @@ class galera::validate(
   Integer $delay,
   Integer $retries,
   Optional[String] $inv_catch,
-  Optional[String] $host = $galera::status_host,
+  Optional[String] $host     = undef,
+  Optional[String] $user     = undef,
+  Optional[String] $password = undef,
 ) {
 
   if $galera::root_password =~ String {


### PR DESCRIPTION
Now galera::status in just included unconditionally in galera::validation so setting status_check to false doesn't prevent installing clustercheck script and xinetd service in case validation = true. I suggest to use for validation either status user/password if they are given and status_check enabled or to use root account as failback