### PR TITLE
re-enable the content-check of validate

### DIFF
--- a/manifests/validate.pp
+++ b/manifests/validate.pp
@@ -37,14 +37,14 @@ class galera::validate(
   }
 
   if $catch {
-    $truecatch = $catch
+    $truecatch = " -v ${catch}"
   } elsif $inv_catch {
-    $truecatch = " -v ${inv_catch}"
+    $truecatch = $inv_catch
   } else {
     fail('No catch method specified in galera validation script')
   }
 
-  $cmd = "mysql --host=${validate_host} --user=${validate_user} --password=${validate_password} -e '${action}'"
+  $cmd = "mysql --host=${validate_host} --user=${validate_user} --password=${validate_password} -e '${action}' | grep -q ${truecatch}"
   exec { 'validate_connection':
     path        => '/usr/bin:/bin:/usr/local/bin:/usr/sbin:/sbin:/usr/local/sbin',
     provider    => shell,


### PR DESCRIPTION
6 years ago the commit a26a8a16d33519d9cc97e8200bc00795ae0560b1 disabled the content-check of validate.

The module just checked if a connection is possible, but doesnt check if f.e. WSREP is ready.
This commit fixes this by re-adding the grep-call