### PR TITLE
Module is not waiting for cluster to sync

### DIFF
--- a/templates/should-we-create-mycnf.erb
+++ b/templates/should-we-create-mycnf.erb
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+test ` cat <%= @facts['root_home'] %>/.my.cnf | /bin/grep -c "password='<%= @root_password %>'" ` -eq 0
+
+for TRY in $( seq 0 30 )
+do
+  if /usr/bin/mysql --user=root --password=<%= @root_password %> -e 'select count(1);' 2>&1 | grep -i 'ACCESS DENIED'
+  then
+    # ACCESS DENIED
+    exit 1
+  fi
+
+  if ! /usr/bin/mysql --user=root --password=<%= @root_password %> -e 'select count(1);' | grep '1'
+  then
+    sleep 1
+  else
+    exit 0
+  fi
+done


### PR DESCRIPTION
We use a ci/cd system to test our deployment and in some (timing-)edge-cases the module is unable bootstrap / setup the galera-cluster, because it tries to do queries while cluster is still "not synced".

This commit is [WIP], because I personally dont like the "file creation" just to do checks, but I currently dont have the time or ideas how to solve this a bit smarter.
