### PR TITLE
take ip-list without port

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -583,7 +583,7 @@ class galera(
     if ($::fqdn == $galera_master) {
       # If there are no other servers up and we are the master, the cluster
       # needs to be bootstrapped. This happens before the service is managed
-      $server_list = join($_nodes_tmp, ' ')
+      $server_list = join($galera_servers, ' ')
 
       exec { 'bootstrap_galera_cluster':
         command  => $params['bootstrap_command'],


### PR DESCRIPTION
nmap call with ports throws an error

**current behavior**
`
Debug: Exec[bootstrap_galera_cluster](provider=shell): Executing check '["/bin/sh", "-c", "nmap -Pn -p 4567 10.0.49.37:4567 10.0.49.16:4567 | grep -q '4567/tcp open'"]'
Debug: Executing: '/bin/sh -c nmap -Pn -p 4567 10.0.49.37:4567 10.0.49.16:4567 | grep -q '4567/tcp open''
Debug: /Stage[main]/Galera/Exec[bootstrap_galera_cluster]/unless: Failed to resolve "10.0.49.37:4567".
Debug: /Stage[main]/Galera/Exec[bootstrap_galera_cluster]/unless: Failed to resolve "10.0.49.16:4567".
Debug: /Stage[main]/Galera/Exec[bootstrap_galera_cluster]/unless: WARNING: No targets were specified, so 0 hosts scanned.
Debug: Exec[bootstrap_galera_cluster](provider=shell): Executing '["/bin/sh", "-c", "/usr/bin/galera_new_cluster"]'
Debug: Executing: '/bin/sh -c /usr/bin/galera_new_cluster'
Notice: /Stage[main]/Galera/Exec[bootstrap_galera_cluster]/returns: executed successfully (corrective)
Info: /Stage[main]/Galera/Exec[bootstrap_galera_cluster]: Scheduling refresh of Exec[validate_connection]
`

**expected behavior**
`
Debug: Exec[bootstrap_galera_cluster](provider=shell): Executing check '["/bin/sh", "-c", "nmap -Pn -p 4567 10.0.49.37 10.0.49.16 | grep -q '4567/tcp open'"]'
Debug: Executing: '/bin/sh -c nmap -Pn -p 4567 10.0.49.37 10.0.49.16 | grep -q '4567/tcp open''
Debug: /Stage[main]/Galera/Exec[bootstrap_galera_cluster]: '/usr/bin/galera_new_cluster' won't be executed because of failed check 'unless'
`

