### PR TITLE
Add extra 0.1sec sleep to handle http-check issue in HAProxy 2.2

### DIFF
--- a/templates/clustercheck.epp
+++ b/templates/clustercheck.epp
@@ -26,6 +26,7 @@ if [ -e "/var/tmp/clustercheck.disabled" ]; then
     echo -en "HTTP/1.1 503 Service Unavailable\r\n"
     echo -en "Content-Type: text/plain\r\n"
     echo -en "Connection: close\r\n"
+    sleep 0.1
     echo -en "Content-Length: 51\r\n"
     echo -en "\r\n"
     echo -en "Percona XtraDB Cluster Node is manually disabled.\r\n"
@@ -71,6 +72,7 @@ then
             echo -en "HTTP/1.1 503 Service Unavailable\r\n"
             echo -en "Content-Type: text/plain\r\n"
             echo -en "Connection: close\r\n"
+            sleep 0.1
             echo -en "Content-Length: 43\r\n"
             echo -en "\r\n"
             echo -en "Percona XtraDB Cluster Node is read-only.\r\n"
@@ -83,6 +85,7 @@ then
     echo -en "HTTP/1.1 200 OK\r\n"
     echo -en "Content-Type: text/plain\r\n"
     echo -en "Connection: close\r\n"
+    sleep 0.1
     echo -en "Content-Length: 40\r\n"
     echo -en "\r\n"
     echo -en "Percona XtraDB Cluster Node is synced.\r\n"
@@ -94,6 +97,7 @@ else
     echo -en "HTTP/1.1 503 Service Unavailable\r\n"
     echo -en "Content-Type: text/plain\r\n"
     echo -en "Connection: close\r\n"
+    sleep 0.1
     echo -en "Content-Length: 44\r\n"
     echo -en "\r\n"
     echo -en "Percona XtraDB Cluster Node is not synced.\r\n"


### PR DESCRIPTION
In HAProxy 2.2.x there is a problem to check cluster state using http-check due `Recv failure` 
The same issue was described few years ago https://github.com/olafz/percona-clustercheck/issues/2