### PR TITLE
Use parameter for service name wherever possible

### DIFF
--- a/manifests/debian.pp
+++ b/manifests/debian.pp
@@ -102,7 +102,7 @@ class galera::debian {
         mode    => '0600',
         content => epp('galera/debian.cnf.epp'),
         require => Exec['clean_up_ubuntu'],
-        before  => Service['mysqld'],
+        before  => Service[$galera::mysql_service_name],
       }
     }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -541,7 +541,7 @@ class galera(
           "mysql --user=root --password=${root_password} -e 'select count(1);'",
           "test `cat ${::root_home}/.my.cnf | grep -c \"password='${root_password}'\"` -eq 0",
           ],
-        require => Service['mysqld'],
+        require => Service[$mysql_service_name],
         before  => [Class['mysql::server::root_password'],Class['galera::status']],
       }
     }
@@ -589,7 +589,7 @@ class galera(
         command  => $params['bootstrap_command'],
         unless   => "nmap -Pn -p ${wsrep_group_comm_port} ${server_list} | grep -q '${wsrep_group_comm_port}/tcp open'",
         require  => Class['mysql::server::installdb'],
-        before   => Service['mysqld'],
+        before   => Service[$mysql_service_name],
         provider => shell,
         path     => '/usr/bin:/bin:/usr/local/bin:/usr/sbin:/sbin:/usr/local/sbin'
       }

--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -34,7 +34,7 @@ class galera::redhat {
         # able to startup as primary node.
         service { 'mysql@bootstrap':
           ensure => 'stopped',
-          before => Service['mysqld'],
+          before => Service[$galera::mysql_service_name],
         }
         Exec<| title == 'bootstrap_galera_cluster' |> -> Service['mysql@bootstrap']
       }

--- a/manifests/validate.pp
+++ b/manifests/validate.pp
@@ -51,7 +51,7 @@ class galera::validate(
     command     => $cmd,
     tries       => $retries,
     try_sleep   => $delay,
-    subscribe   => Service['mysqld'],
+    subscribe   => Service[$galera::mysql_service_name],
     refreshonly => true,
   }
 


### PR DESCRIPTION
If the Service name is not mysqld it could be added per parameter but some calls doesn't use this param. This should be fixed